### PR TITLE
Update pack.cpp

### DIFF
--- a/src/pack.cpp
+++ b/src/pack.cpp
@@ -85,7 +85,7 @@ int32_t pack::SetInstallDir(char* strDirectory)
 {
 	installDir = std::string(strDirectory);
 
-	/* We don't know what this is supposed to return */
+	/* Always returns 0, no matter what happens. */
 	return 0;
 }
 


### PR DESCRIPTION
SetInstallDir is hardcoded to always return 0. Validated through RE.